### PR TITLE
[FEATURE] Rounding calculated recommended price for visual appeal

### DIFF
--- a/AllaganMarket/Settings/RoundToSetting.cs
+++ b/AllaganMarket/Settings/RoundToSetting.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+using AllaganLib.Interface.FormFields;
+using AllaganLib.Interface.Services;
+
+namespace AllaganMarket.Settings;
+
+public class RoundToSetting : IntegerFormField<Configuration>, ISetting
+{
+    public RoundToSetting(ImGuiService imGuiService) : base(imGuiService)
+    {
+    }
+
+    public override int DefaultValue { get; set; } = 1;
+
+    public override string Key { get; set; } = "RoundTo";
+
+    public override string Name { get; set; } = "Round the recommended price to the nearest multiple of";
+
+    public override string HelpText { get; set; } =
+        "When displaying a recommended undercut price, this indicates the nearest multiple to which the recommended price is rounded to. Set to 1 if you don't want to round off the recommended pricing.";
+
+    public override string Version { get; } = "1.0.0.1";
+
+    public SettingType Type { get; set; } = SettingType.Undercutting;
+}

--- a/AllaganMarket/Settings/RoundUpDownSetting.cs
+++ b/AllaganMarket/Settings/RoundUpDownSetting.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+
+using AllaganLib.Interface.FormFields;
+using AllaganLib.Interface.Services;
+
+namespace AllaganMarket.Settings;
+
+
+public class RoundUpDownSetting : BooleanFormField<Configuration>, ISetting
+{
+    public RoundUpDownSetting(ImGuiService imGuiService)
+            : base(imGuiService)
+    {
+    }
+    public override bool DefaultValue { get; set; } = false;
+
+    public override string Key { get; set; } = "RoundUpDown";
+
+    public override string Name { get; set; } = "Round up or down";
+
+    public override string HelpText { get; set; } = "Checking this box will round the recommended price UP from the undercut calcuations. You might want to do this if you undercut by a larger number and want a visually pleasing result. Leaving the box unchecked will round DOWN.";
+
+    public override string Version { get; } = "1.0.0.1";
+
+    public SettingType Type { get; set; } = SettingType.Undercutting;
+}
+

--- a/AllaganMarket/Windows/RetainerSellOverlayWindow.cs
+++ b/AllaganMarket/Windows/RetainerSellOverlayWindow.cs
@@ -204,7 +204,7 @@ public class RetainerSellOverlayWindow : OverlayWindow
                     break;
             }
 
-            var recommendedUnitPrice = this.undercutService.GetRecommendedUnitPrice(activeRetainer.WorldId, currentItem.Value.RowId, isHq ?? false);
+            var recommendedUnitPrice = this.undercutService.GetRecommendedUnitPrice(activeRetainer.WorldId, currentItem.Value.RowId, isHq ?? false, 1, false);
             var lastUpdated = this.undercutService.GetLastUpdateTime(activeRetainer.WorldId, currentItem.Value.RowId);
             var recommendedPrice = recommendedUnitPrice == null ? "No Data" : recommendedUnitPrice.Value.ToString();
 


### PR DESCRIPTION
 Adds a rounding feature to the recommended price calculations. Values are set in the Undercutting section of the configuration, and can be 'disabled' by setting rounding value to 1,  with a boolean checkbox for rounding up/down.  Rounding up would be mostly for visual appeal if you have a large undercut value. 

Rounded values are multiples of the user supplied value, i.e. 5 or 10 but can take any logical number. Values less than 1 are set to 1 to prevent division by zero errors. 