### PR TITLE
Fixed issue with config variable retreived but not used.

### DIFF
--- a/AllaganMarket/Services/UndercutService.cs
+++ b/AllaganMarket/Services/UndercutService.cs
@@ -185,7 +185,11 @@ public class UndercutService : IHostedService, IMediatorSubscriber
         // Config details here
         var roundDir = this.roundUpDownSetting.CurrentValue(this.configuration);
         var roundTo = this.roundToSetting.CurrentValue(this.configuration);
-
+        // If the user has set a custom value, use that instead of the default. Prevent potential issues with evaluating null variables below.
+        if (roundDir == true )
+        {
+            roundUpDown = true;
+        }
         undercutComparison = this.configuration.GetUndercutComparison(itemId) ?? undercutComparison;
 
         bool? requestedQuality = null;


### PR DESCRIPTION
Rounding direction boolean was retrieved from config but the up/down statements were using sanity default of false (down) only. Will now use value of config if it's true, otherwise continues with default of false. Prevents assignment and evaluating of a possibly null value. 